### PR TITLE
Add roster tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ A small LangChain-based assistant for checking NBA stats and schedules.
 ## Features
 - **Command-line chat** via `chat.py`.
 - **Streamlit web app** using `app.py`.
-- Tools for player stats and team schedules located in `tools.py`. The stats tool now also exposes shooting percentages (FG%, 3P%, FT%) when available.
+- Tools for player stats, team schedules, and standings located in `tools.py`.
+- **New:** Team roster lookup via the `nba_roster` tool.
+- The stats tool now also exposes shooting percentages (FG%, 3P%, FT%) when available.
 - Local caching of API requests under `cache.py`.
 
 ## Usage

--- a/agent.py
+++ b/agent.py
@@ -2,14 +2,14 @@
 import os
 from langchain.agents import initialize_agent, AgentType
 from langchain_community.chat_models import ChatOpenAI
-from tools import StatsTool, ScheduleTool, StandingsTool
+from tools import StatsTool, ScheduleTool, StandingsTool, RosterTool
 from judgeval.common.tracer import Tracer
 
 def build_agent():
     llm = ChatOpenAI(model_name="gpt-4o-mini", temperature=0)
     tracer = Tracer(project_name="nba_agent")   # trace everything
     return initialize_agent(
-        tools=[StatsTool(), ScheduleTool(), StandingsTool()],
+        tools=[StatsTool(), ScheduleTool(), StandingsTool(), RosterTool()],
         llm=llm,
         agent=AgentType.CHAT_ZERO_SHOT_REACT_DESCRIPTION,
         verbose=True,  # Enable verbose mode to see what's happening

--- a/tests/fixtures/roster_5.json
+++ b/tests/fixtures/roster_5.json
@@ -1,0 +1,7 @@
+{
+  "data": [
+    {"first_name": "Stephen", "last_name": "Curry"},
+    {"first_name": "Klay", "last_name": "Thompson"},
+    {"first_name": "Draymond", "last_name": "Green"}
+  ]
+}

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -29,7 +29,14 @@ if 'requests' not in sys.modules:
     requests.get = dummy_get
     sys.modules['requests'] = requests
 
-from tools import StatsTool, ScheduleTool, StandingsTool, _lookup_id
+from tools import (
+    StatsTool,
+    ScheduleTool,
+    StandingsTool,
+    RosterTool,
+    _lookup_id,
+    _lookup_team_id,
+)
 from cache import _path_for_key, _memory_cache
 
 
@@ -56,6 +63,21 @@ def test_schedule_tool_returns_game():
     tool = ScheduleTool()
     out = tool._run('Warriors')
     assert 'Next Warriors game' in out
+
+
+def test_roster_tool():
+    tool = RosterTool()
+    key = f"roster_{_lookup_team_id('Warriors')}"
+    cache_file = _path_for_key(key)
+    if cache_file.exists():
+        cache_file.unlink()
+    if key in _memory_cache:
+        del _memory_cache[key]
+
+    data = json.loads(tool._run('Warriors'))
+    assert data['team'].startswith('Warriors') or data['team'].startswith('Golden')
+    assert any('Curry' in p for p in data['roster'])
+    assert cache_file.exists()
 
 
 def test_standings_tool():


### PR DESCRIPTION
## Summary
- allow the agent to return NBA team rosters using a new `nba_roster` tool
- expose the tool via `build_agent`
- document the roster feature
- test the roster tool

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a48a05208328b28c5ff424c0c3a8