### PR TITLE
Fix season-stat parsing in StatsTool

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -108,6 +108,12 @@ def test_new_player_stats():
     assert result['player'].startswith('Shai')
     assert 'ppg' in result['stats']
 
+def test_player_season_stat_order():
+    tool = StatsTool()
+    result = json.loads(tool._run('LeBron 2024-25 points'))
+    assert result['player'] == 'Lebron'
+    assert list(result['stats'].keys()) == ['ppg']
+
 
 def test_stats_tool_remote(monkeypatch):
     tool = StatsTool()

--- a/tools.py
+++ b/tools.py
@@ -65,6 +65,24 @@ class StatsTool(BaseTool):
         player = ""
         stat_type = "all"
         season = "2024-25"
+        stat_keywords = [
+            "points",
+            "assists",
+            "rebounds",
+            "steals",
+            "blocks",
+            "ppg",
+            "apg",
+            "rpg",
+            "fg%",
+            "fg_pct",
+            "fg3%",
+            "fg3_pct",
+            "3p%",
+            "3p_pct",
+            "ft%",
+            "ft_pct",
+        ]
 
         if len(parts) == 1:
             player = parts[0]
@@ -79,27 +97,15 @@ class StatsTool(BaseTool):
             for i, part in enumerate(parts):
                 if part in ["2023-24", "2024-25", "2022-23"]:
                     season = part
-                    player = " ".join(parts[: i - 1]) if i > 1 else parts[0]
-                    stat_type = parts[i - 1] if i > 1 else "all"
+                    # if a stat follows the season, use it
+                    if i + 1 < len(parts) and parts[i + 1] in stat_keywords:
+                        player = " ".join(parts[:i])
+                        stat_type = parts[i + 1]
+                    else:
+                        player = " ".join(parts[: i - 1]) if i > 1 else parts[0]
+                        stat_type = parts[i - 1] if i > 1 else "all"
                     break
-                elif part in [
-                    "points",
-                    "assists",
-                    "rebounds",
-                    "steals",
-                    "blocks",
-                    "ppg",
-                    "apg",
-                    "rpg",
-                    "fg%",
-                    "fg_pct",
-                    "fg3%",
-                    "fg3_pct",
-                    "3p%",
-                    "3p_pct",
-                    "ft%",
-                    "ft_pct",
-                ]:
+                elif part in stat_keywords:
                     player = " ".join(parts[:i])
                     stat_type = part
                     if i + 1 < len(parts):


### PR DESCRIPTION
## Summary
- handle queries with season before stat
- add tests for parsing order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e72c0b108328bd3806547ba5025f