### PR TITLE
Add agentic planning interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A LangChain-based assistant for checking NBA stats and schedules with enhanced u
 - **Advanced Features:** Shooting percentages (FG%, 3P%, FT%), team analytics, and more
 - Local caching of API requests for faster responses
 - Comprehensive test suite with Judgment Labs integration
+- **Agentic Planning Mode** with conversation memory
 
 ## Architecture
 
@@ -66,6 +67,9 @@ python launcher.py web
 # Terminal chat interface
 python launcher.py chat
 
+# Agentic planning chat
+python launcher.py plan
+
 # Run test suite
 python launcher.py tests all
 ```
@@ -74,6 +78,11 @@ python launcher.py tests all
 Run the interactive chat in your terminal:
 ```bash
 python apps/chat.py
+```
+
+Use the planning agent:
+```bash
+python apps/chat_planner.py
 ```
 
 Launch the enhanced web interface:
@@ -110,7 +119,8 @@ nba_agent/
 ├── apps/                   # Application interfaces
 │   ├── app_ux_improved.py # Enhanced web interface
 │   ├── app.py             # Original Streamlit app
-│   └── chat.py            # Terminal chat interface
+│   ├── chat.py            # Terminal chat interface
+│   └── chat_planner.py    # Agentic planning chat
 ├── scripts/               # Utility scripts
 │   ├── start_web.sh      # Web app launcher script
 │   └── activate_env.sh   # Environment activation
@@ -130,5 +140,6 @@ nba_agent/
 - **`src/tools.py`** - NBA stats and schedule tools
 - **`apps/app_ux_improved.py`** - Enhanced Streamlit interface
 - **`apps/chat.py`** - Terminal chat interface
+- **`apps/chat_planner.py`** - Planning chat interface
 - **`scripts/start_web.sh`** - Shell script to start web app
 

--- a/apps/chat_planner.py
+++ b/apps/chat_planner.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Interactive chat using the PlanningAgent."""
+
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from agent import build_planning_agent
+
+
+def main():
+    print("🏀 NBA Planner Agent Chat")
+    print("=" * 50)
+    print("Ask me complex NBA questions and I'll plan the steps!")
+    print("Type 'quit' to exit.\n")
+
+    agent = build_planning_agent()
+
+    while True:
+        try:
+            question = input("🤔 Ask: ").strip()
+            if question.lower() in {"quit", "exit", "bye"}:
+                print("👋 Goodbye!")
+                break
+            if not question:
+                continue
+
+            print("🤖 Planning...")
+            result = agent.invoke({"input": question})
+            plan = result.get("plan", "")
+            answer = result.get("answer", "")
+            if plan:
+                print("📝 Plan:\n" + plan)
+            print(f"📊 {answer}\n")
+        except KeyboardInterrupt:
+            print("\n👋 Goodbye!")
+            break
+        except Exception as e:
+            print(f"❌ Error: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/launcher.py
+++ b/launcher.py
@@ -16,6 +16,7 @@ def main():
         print("  web       - Original Streamlit web interface")
         print("  web-ux    - Enhanced UX Streamlit interface")
         print("  chat      - Terminal chat interface")
+        print("  plan      - Agentic planning chat")
         print("  tests     - Run test suite")
         print("\nExample: python launcher.py web-ux")
         return
@@ -31,6 +32,9 @@ def main():
     elif app_name == "chat":
         print("🏀 Starting terminal chat interface...")
         subprocess.run([sys.executable, "apps/chat.py"])
+    elif app_name == "plan":
+        print("🏀 Starting planning chat interface...")
+        subprocess.run([sys.executable, "apps/chat_planner.py"])
     elif app_name == "tests":
         print("🏀 Running test suite...")
         if len(sys.argv) > 2:

--- a/src/agent.py
+++ b/src/agent.py
@@ -2,11 +2,16 @@
 import os
 from langchain.agents import initialize_agent, AgentType
 from langchain_openai import ChatOpenAI
+from langchain.memory import ConversationBufferMemory
+from langchain.schema import BaseMessage
 from tools import StatsTool, ScheduleTool, StandingsTool, RosterTool, ArenaTool
 
 def build_agent():
     llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
-    
+
+    # Conversation memory allows the agent to maintain context across turns
+    memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True)
+
     # Initialize agent without tracer if Judgment credentials are missing
     agent_kwargs = {
         "tools": [StatsTool(), ScheduleTool(), StandingsTool(), RosterTool(), ArenaTool()],
@@ -16,7 +21,8 @@ def build_agent():
         "max_iterations": 5,  # Increase iteration limit
         "max_execution_time": 30,  # Set execution time limit to 30 seconds
         "early_stopping_method": "generate",  # Better stopping method
-        "handle_parsing_errors": True  # Handle parsing errors gracefully
+        "handle_parsing_errors": True,  # Handle parsing errors gracefully
+        "memory": memory,
     }
     
     # Add tracer only if Judgment API key is available
@@ -32,3 +38,36 @@ def build_agent():
         print(f"⚠️  Running without Judgment tracing: {e}")
     
     return initialize_agent(**agent_kwargs)
+
+
+class PlanningAgent:
+    """Wrapper agent that generates a plan before answering."""
+
+    def __init__(self):
+        self.llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+        self.base_agent = build_agent()
+
+    def _generate_plan(self, question: str) -> str:
+        prompt = (
+            "You are an NBA assistant planning a strategy to answer the user's question. "
+            "Break the question into short numbered steps."
+        )
+        resp = self.llm.invoke(f"{prompt}\nQuestion: {question}\nPlan:")
+        # resp can be a message or string depending on llm implementation
+        if isinstance(resp, BaseMessage):
+            return resp.content
+        return str(resp)
+
+    def invoke(self, inputs: dict):
+        question = inputs.get("input", "")
+        plan = self._generate_plan(question)
+        answer = self.base_agent.invoke({"input": question}).get("output", "")
+        return {"plan": plan, "answer": answer}
+
+    def run(self, question: str) -> str:
+        return self.invoke({"input": question})["answer"]
+
+
+def build_planning_agent() -> PlanningAgent:
+    """Create a PlanningAgent for step-by-step reasoning."""
+    return PlanningAgent()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,7 +1,8 @@
 #judgment assert tests
-from agent import build_agent
+from agent import build_agent, build_planning_agent
 
 agent = build_agent()
+planning_agent = build_planning_agent()
 
 def test_lebron_ppg():
     out = agent.run("What was LeBron's PPG in 2024-25?")
@@ -10,3 +11,7 @@ def test_lebron_ppg():
 def test_warriors_next_game():
     out = agent.run("When do the Warriors play next?")
     assert "warriors" in out.lower()
+
+def test_planning_agent():
+    result = planning_agent.invoke({"input": "When is the next Lakers game?"})
+    assert "plan" in result and "answer" in result


### PR DESCRIPTION
## Summary
- implement conversation memory in `build_agent`
- add `PlanningAgent` with planning step
- provide new CLI `chat_planner.py`
- extend launcher and docs for planning mode
- test planning agent in `test_core`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tools')*

------
https://chatgpt.com/codex/tasks/task_e_6887b8c270888328b1f564e6aacf01d8