### PR TITLE
Fix query validation pattern rejecting hyphenated inputs

### DIFF
--- a/src/validation.py
+++ b/src/validation.py
@@ -47,7 +47,11 @@ class InputValidator:
         r'<script.*?>',     # XSS attempts
         r'javascript:',     # JavaScript injection
         r'[<>"\']',         # HTML/SQL injection characters
-        r'[;|\-\-]',        # SQL injection patterns
+        # Match SQL injection patterns like ';', '|', or '--' without blocking
+        # legitimate hyphenated inputs (e.g., seasons like 2024-25)
+        r';',
+        r'\|',
+        r'--',
         r'union\s+select',  # SQL injection
         r'drop\s+table',    # SQL injection
     ]


### PR DESCRIPTION
## Summary
- allow hyphenated queries in validation logic by updating regex patterns

## Testing
- `python - <<'PY'
import sys
sys.path.append('src')
from validation import InputValidator
print(InputValidator.validate_query('scoring 2024-25'))
PY`
- `pytest -q -o addopts="" tests/test_tools.py::test_tool_exists` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68899fd55a2c8328b82e7870fdfbda34